### PR TITLE
Jcentre is no longer available over http

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
This was stopping maven from building locally:
https://jfrog.com/jcenter-http/